### PR TITLE
Enhance automcp init to Generate pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ mcp_crewai = create_crewai_adapter(
 )
 ```
 
+Edit the generated `pyproject.toml` file to add your framework-specific dependencies (like `crewai`, `langgraph`, etc.):
+
+```toml
+[project]
+# ... other project settings ...
+
+dependencies = [
+    "naptha-automcp",
+    "mcp>=1.6.0",
+    "pydantic>=2.11.1",
+    # Add framework-specific dependencies here:
+    "crewai>=0.108.0",
+    "crewai-tools>=0.38.1",
+]
+```
+
 Install dependencies and run your MCP server:
 
 ```bash
@@ -83,7 +99,7 @@ automcp serve -t sse
 
 ## 📁 Generated Files
 
-When you run `automcp init -f <FRAMEWORK>`, the following file is generated:
+When you run `automcp init -f <FRAMEWORK>`, the following files are generated:
 
 ### run_mcp.py
 
@@ -100,6 +116,19 @@ You'll need to edit this file to:
 - Define your input schema (the parameters your agent accepts)
 - Configure the adapter with your agent
 
+### pyproject.toml
+
+This file defines your Python project structure and dependencies. The generated file includes:
+
+- Basic project metadata (name derived from the directory, version, etc.)
+- Core dependencies: `naptha-automcp`, `mcp`, `pydantic`.
+- Build system configuration using `hatchling`.
+- Script entry points (`serve_stdio`, `serve_sse`) for running the server with `uv run`.
+
+You'll need to edit this file to:
+
+- Add dependencies specific to your chosen agent framework (e.g., `crewai`, `langgraph`).
+- Add any other dependencies your agent requires.
 
 ## 🔍 Examples
 
@@ -132,10 +161,11 @@ automcp serve -t sse
 
 Each example follows the same workflow as a regular project:
 
-1. Run `automcp init -f <FRAMEWORK>` to generate the server files
+1. Run `automcp init -f <FRAMEWORK>` to generate the server files (`run_mcp.py`, `pyproject.toml`)
 2. Edit `run_mcp.py` to import and configure the example agent
-3. Add a .env file with necessary environmental variables
-4. Install dependencies and serve using `automcp serve -t sse`
+3. Edit `pyproject.toml` to ensure all necessary dependencies (including the framework itself) are listed
+4. Add a .env file with necessary environmental variables
+5. Install dependencies (`uv sync` or `pip install -e .`) and serve using `automcp serve -t sse`
 
 ### CrewAI example
 Here's what a typical configured `run_mcp.py` looks like for a CrewAI example:

--- a/automcp/cli.py
+++ b/automcp/cli.py
@@ -3,7 +3,7 @@ import sys
 import subprocess
 import yaml
 from pathlib import Path
-import tomllib
+import toml
 import re
 
 # Determine the location of the templates relative to this file
@@ -101,9 +101,9 @@ def init_command(args) -> None:
 
                 # Parse the template TOML to get base dependencies
                 try:
-                    parsed_data = tomllib.loads(template_content)
+                    parsed_data = toml.loads(template_content)
                     base_deps = parsed_data.get("project", {}).get("dependencies", [])
-                except tomllib.TOMLDecodeError as e:
+                except toml.TomlDecodeError as e:
                     print(f"Warning: Could not parse pyproject.toml template: {e}", file=sys.stderr)
                     base_deps = [ # Fallback to known base deps if parse fails
                         "naptha-automcp",

--- a/automcp/cli.py
+++ b/automcp/cli.py
@@ -3,6 +3,8 @@ import sys
 import subprocess
 import yaml
 from pathlib import Path
+import tomllib
+import re
 
 # Determine the location of the templates relative to this file
 _CLI_DIR = Path(__file__).parent
@@ -55,10 +57,11 @@ def create_mcp_server_file(directory: Path, framework: str) -> None:
     if not adapter_variable_name:
         adapter_variable_name = f"mcp_{framework}"
     
-    # Replace all placeholders
+    # Replace all placeholders except dependencies
     for key, value in framework_config.items():
-        placeholder = f"{{{{{key}}}}}"
-        content = content.replace(placeholder, value)
+        if isinstance(value, str): # Only replace if the value is a string
+            placeholder = f"{{{{{key}}}}}"
+            content = content.replace(placeholder, value)
     
     # Replace adapter_variable_name placeholder
     content = content.replace("{{adapter_variable_name}}", adapter_variable_name)
@@ -92,9 +95,66 @@ def init_command(args) -> None:
             print(f"Warning: pyproject.toml template not found at {_PYPROJECT_TEMPLATE_FILE}", file=sys.stderr)
         else:
             try:
-                with open(_PYPROJECT_TEMPLATE_FILE, "r") as f_template, open(pyproject_path, "w") as f_dest:
-                    f_dest.write(f_template.read())
-                print(f"Created {pyproject_path}")
+                # Read the template content
+                with open(_PYPROJECT_TEMPLATE_FILE, "r") as f_template:
+                    template_content = f_template.read()
+
+                # Parse the template TOML to get base dependencies
+                try:
+                    parsed_data = tomllib.loads(template_content)
+                    base_deps = parsed_data.get("project", {}).get("dependencies", [])
+                except tomllib.TOMLDecodeError as e:
+                    print(f"Warning: Could not parse pyproject.toml template: {e}", file=sys.stderr)
+                    base_deps = [ # Fallback to known base deps if parse fails
+                        "naptha-automcp",
+                        "mcp>=1.6.0",
+                        "pydantic>=2.11.1",
+                    ]
+                
+                # Get project name from current directory for replacement
+                project_name = current_dir.name.replace(" ", "_").lower() 
+                output_content = template_content.replace(
+                    'name = "mcp-project"', 
+                    f'name = "{project_name}"'
+                )
+
+                # Load framework config to get framework-specific dependencies
+                framework_deps = []
+                try:
+                    with open(_CONFIG_FILE, "r") as f_config:
+                        config = yaml.safe_load(f_config)
+                        framework_deps = config.get("frameworks", {}).get(args.framework, {}).get("dependencies", [])
+                except Exception as e:
+                    print(f"Warning: Could not load framework dependencies from {_CONFIG_FILE}: {e}", file=sys.stderr)
+
+                # Combine base and framework dependencies, maintaining order and removing duplicates
+                combined_deps = []
+                seen_deps = set()
+                for dep in base_deps + framework_deps:
+                    if dep not in seen_deps:
+                        combined_deps.append(dep)
+                        seen_deps.add(dep)
+
+                # Format the combined dependencies list into TOML string
+                deps_list_str = "dependencies = [\n"
+                for dep in combined_deps:
+                    deps_list_str += f'    "{dep}",\n'
+                deps_list_str += "]"
+
+                # Replace the old dependencies block with the new one using regex
+                # This regex finds the whole 'dependencies = [...]' block
+                output_content = re.sub(
+                    r"^dependencies\s*=\s*\[.*?^\]", 
+                    deps_list_str, 
+                    output_content, 
+                    flags=re.MULTILINE | re.DOTALL
+                )
+
+                # Write the modified content
+                with open(pyproject_path, "w") as f_dest:
+                    f_dest.write(output_content)
+                print(f"Created {pyproject_path} for project '{project_name}' with {args.framework} dependencies.")
+
             except IOError as e:
                 print(f"Error writing {pyproject_path}: {e}", file=sys.stderr)
     else:
@@ -102,9 +162,10 @@ def init_command(args) -> None:
 
     print("\nSetup complete! Next steps:")
     print(f"1. Edit {current_dir / 'run_mcp.py'} to import and configure your {args.framework} agent/crew/graph")
-    print(f"2. Edit {pyproject_path} to add framework-specific dependencies (e.g., crewai, langgraph)")
+    print(f"2. Verify dependencies in {pyproject_path} and add any additional ones needed by your agent or remove the ones that are not needed.")
     print("3. Add a .env file with necessary environment variables")
-    print("4. Run your MCP server using one of these commands:")
+    print("4. Run `uv sync` to install dependencies.")
+    print("5. Run your MCP server using one of these commands:")
     print("   - automcp serve         # For STDIO transport (default)")
     print("   - automcp serve -t sse     # For SSE transport")
     print("   - uv run serve_stdio           # Using the script entry point (if using uv)")

--- a/automcp/cli.py
+++ b/automcp/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 _CLI_DIR = Path(__file__).parent
 _TEMPLATE_FILE = _CLI_DIR / "cli_templates/run_mcp.py.template"
 _CONFIG_FILE = _CLI_DIR / "cli_templates/framework_config.yaml"
+_PYPROJECT_TEMPLATE_FILE = _CLI_DIR / "cli_templates/pyproject.toml.template"
 
 
 def create_mcp_server_file(directory: Path, framework: str) -> None:
@@ -84,10 +85,26 @@ def init_command(args) -> None:
         print(f"Error writing server file: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Create pyproject.toml if it doesn't exist
+    pyproject_path = current_dir / "pyproject.toml"
+    if not pyproject_path.exists():
+        if not _PYPROJECT_TEMPLATE_FILE.exists():
+            print(f"Warning: pyproject.toml template not found at {_PYPROJECT_TEMPLATE_FILE}", file=sys.stderr)
+        else:
+            try:
+                with open(_PYPROJECT_TEMPLATE_FILE, "r") as f_template, open(pyproject_path, "w") as f_dest:
+                    f_dest.write(f_template.read())
+                print(f"Created {pyproject_path}")
+            except IOError as e:
+                print(f"Error writing {pyproject_path}: {e}", file=sys.stderr)
+    else:
+        print(f"{pyproject_path} already exists, skipping creation.")
+
     print("\nSetup complete! Next steps:")
     print(f"1. Edit {current_dir / 'run_mcp.py'} to import and configure your {args.framework} agent/crew/graph")
-    print("2. Add a .env file with necessary environment variables")
-    print("3. Run your MCP server using one of these commands:")
+    print(f"2. Edit {pyproject_path} to add framework-specific dependencies (e.g., crewai, langgraph)")
+    print("3. Add a .env file with necessary environment variables")
+    print("4. Run your MCP server using one of these commands:")
     print("   - automcp serve         # For STDIO transport (default)")
     print("   - automcp serve -t sse     # For SSE transport")
     print("   - uv run serve_stdio           # Using the script entry point (if using uv)")

--- a/automcp/cli_templates/framework_config.yaml
+++ b/automcp/cli_templates/framework_config.yaml
@@ -9,6 +9,9 @@ frameworks:
           description=description,
           input_schema=InputSchema,
       )
+    dependencies:
+      - "crewai>=0.108.0"
+      - "crewai-tools>=0.38.1"
 
   mcp_agent:
     adapter_import: automcp.adapters.mcp_agent import create_mcp_agent_adapter
@@ -23,6 +26,9 @@ frameworks:
           description=description,
           input_schema=InputSchema,
       )
+    dependencies:
+      - "mcp-agent"
+      - "langchain-openai==0.2.14"
 
   langgraph:
     adapter_import: automcp.adapters.langgraph import create_langgraph_adapter
@@ -34,6 +40,11 @@ frameworks:
           description=description,
           input_schema=InputSchema,
       )
+    dependencies:
+      - "langchain-openai==0.2.14"
+      - "langchain==0.3.20"
+      - "langgraph==0.3.25"
+      - "langchain-core>=0.3.51"
 
   pydantic:
     adapter_import: automcp.adapters.pydantic import create_pydantic_adapter
@@ -45,6 +56,8 @@ frameworks:
           description=description,
           input_schema=InputSchema,
       )
+    dependencies:
+      - "pydantic-ai==0.0.43"
   
   llamaindex:
     adapter_import: automcp.adapters.llamaindex import create_llamaindex_adapter
@@ -56,6 +69,10 @@ frameworks:
           description=description,
           input_schema=InputSchema,
       )
+    dependencies:
+      - "llama-index>=0.12.28"
+      - "llama-index-core>=0.12.28"
+      - "llama-index-llms-openai"
 
   openai:
     adapter_import: automcp.adapters.openai import create_openai_adapter
@@ -67,4 +84,6 @@ frameworks:
           description=description,
           input_schema=InputSchema,
       )
+    dependencies:
+      - "openai-agents>=0.0.9"
           

--- a/automcp/cli_templates/pyproject.toml.template
+++ b/automcp/cli_templates/pyproject.toml.template
@@ -1,0 +1,28 @@
+[project]
+name = "mcp-project"
+version = "0.1.0"
+description = "A project with MCP server integration"
+requires-python = ">=3.11"
+dependencies = [
+    "naptha-automcp",
+    "mcp>=1.6.0",
+    "pydantic>=2.11.1",
+    "uv>=0.6.6"
+]
+
+[build-system]
+requires = [ "hatchling",]
+build-backend = "hatchling.build"
+
+[project.scripts]
+serve_stdio = "run_mcp:serve_stdio"
+serve_sse = "run_mcp:serve_sse"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+include = [ "run_mcp.py",]
+exclude = [ "__pycache__", "*.pyc",]
+sources = [ ".",]
+packages = ["."] 

--- a/automcp/cli_templates/run_mcp.py.template
+++ b/automcp/cli_templates/run_mcp.py.template
@@ -25,7 +25,7 @@ class InputSchema(BaseModel):
     query: str
     # Add more parameters as needed
 
-name = "Your Agent Name"
+name = "your_agent_name" # Make sure name follows snake_case
 description = "Description of what your agent does"
 
 # Create an adapter for {{framework}}


### PR DESCRIPTION
This PR enhances the `automcp init` command to streamline the setup process for new MCP server projects. Previously, users only received a `run_mcp.py` file. Now, `automcp init` also generates a standard `pyproject.toml file`, pre-populated with essential configurations and dependencies.

Key Changes:
1. pyproject.toml Generation:
The `automcp init -f <framework>` command now creates a pyproject.toml file in the target directory if one doesn't already exist.
A new template file (`automcp/cli_templates/pyproject.toml.template`) has been added, containing base project structure, build system config (hatchling), and script entry points (`serve_stdio`, `serve_sse`).

2. Dynamic Configuration:
The generated `pyproject.toml` automatically sets the [project] name based on the current directory's name.
Crucially, it reads framework-specific dependencies from `automcp/cli_templates/framework_config.yaml`.

3. Documentation & Usability:
The `README.md` has been updated to explain the new pyproject.toml generation, guide users on verifying/adding dependencies, and reflect the updated workflow.
The "Next steps" instructions printed by automcp init have been modified to guide the user regarding the new `pyproject.toml` and dependency installation (uv sync).